### PR TITLE
Add markupsafe==2.0.1

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn==0.23.2
 scikit-image==0.17.2
 tensorflow==2.3.0
 protobuf==3.20.*
+markupsafe==2.0.1


### PR DESCRIPTION
Pin markupsafe to 2.0.1 to workaround [ a unfixed jinja2 issue](https://github.com/pallets/jinja/issues/1585) 